### PR TITLE
Add support for reading Markdown from the standard input

### DIFF
--- a/src/md2mld.ml
+++ b/src/md2mld.ml
@@ -5,19 +5,28 @@
 (* http://www.isc.org/downloads/software-support-policy/isc-license/   *)
 (***********************************************************************)
 
-let readall filename =
-  let ic = open_in filename in
+let readall ic =
+  let return_input ic buf =
+    let () = close_in ic in
+    buf |> Buffer.to_bytes |> Bytes.to_string
+  in
+  let channel_size =
+    try Some (in_channel_length ic)
+    with Sys_error _ -> None
+  in
+  let buf = Buffer.create @@ Option.value ~default:4096 channel_size in
   try
-    let n = in_channel_length ic in
-    let b = Bytes.create n in
-    really_input ic b 0 n;
-    close_in ic;
-    Bytes.to_string b
+    let () =
+      while true do
+        Buffer.add_channel buf ic 4096
+      done
+    in return_input ic buf
   with
-  | exn ->
-    close_in ic;
+  | End_of_file ->
+    return_input ic buf
+  | _ as exn ->
+    let () = close_in ic in
     raise exn
-
 
 (*
 let writeall filename content =
@@ -27,6 +36,12 @@ let writeall filename content =
     close_out oc
   with exn -> close_out oc ; raise exn
 *)
+
+let get_input_channel file_arg =
+  match file_arg with
+  | [] -> stdin
+  | [ filename ] -> open_in filename
+  | _ -> raise (Invalid_argument "Cannot handle multiple input files")
 
 let _ =
   let input_files = ref [] in
@@ -45,16 +60,18 @@ let _ =
   in
   Arg.parse speclist (fun filename -> input_files := filename :: !input_files) usage_msg;
   match !input_files with
-  | [] | _ :: _ :: _ ->
-    Arg.usage speclist usage_msg;
-    exit 1
   | [ filename ] when not (Sys.file_exists filename) ->
     Printf.eprintf "error: file %s not found\n%!" filename;
     exit 2
-  | [ filename ] ->
+  | [] | [ _ ] ->
     let min_head_lvl = !min_header in
-    readall filename
+    let ic = get_input_channel !input_files in
+    readall ic
     |> Omd.of_string
     |> Backend.mld_of_md ~min_head_lvl
     |> String.trim
     |> print_endline
+  | _ ->
+    Arg.usage speclist usage_msg;
+    exit 1
+


### PR DESCRIPTION
I used the usual UNIX convention: if `md2mld` is run without arguments, it acts as a filter so that one can run `cat file.md | md2mld`.