### PR TITLE
Add support for -version option

### DIFF
--- a/md2mld.opam
+++ b/md2mld.opam
@@ -1,5 +1,3 @@
-version: "2fb995c-dirty"
-version: "2fb995c"
 opam-version: "2.0"
 name: "md2mld"
 synopsis: "Little cli tool to convert md files into mld files"
@@ -16,7 +14,7 @@ depends: [
   "omd" {>= "2.0.0~alpha2"}
 ]
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
 ]
 dev-repo: "git+https://github.com/mseri/md2mld.git"

--- a/md2mld.opam
+++ b/md2mld.opam
@@ -1,3 +1,5 @@
+version: "2fb995c-dirty"
+version: "2fb995c"
 opam-version: "2.0"
 name: "md2mld"
 synopsis: "Little cli tool to convert md files into mld files"
@@ -13,5 +15,8 @@ depends: [
   "base-bytes"
   "omd" {>= "2.0.0~alpha2"}
 ]
-build: ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
 dev-repo: "git+https://github.com/mseri/md2mld.git"

--- a/md2mld.opam
+++ b/md2mld.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mseri/md2mld"
 doc: "https://mseri.github.io/md2mld/"
 bug-reports: "https://github.com/mseri/md2mld/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
   "base-bytes"
   "omd" {>= "2.0.0~alpha2"}

--- a/src/md2mld.ml
+++ b/src/md2mld.ml
@@ -49,7 +49,10 @@ let _ =
   let speclist =
     [ ( "-min-header"
       , Arg.Set_int min_header
-      , "Minimal section header level. Defaults to 0." )
+      , "Minimal section header level. Defaults to 0." );
+      ( "-version"
+      , Arg.Unit (fun () -> print_endline "%%NAME%% %%VERSION%%"; exit 0)
+      , "Print version and exit." )
     ]
   in
   let usage_msg =


### PR DESCRIPTION
As discussed. I hope I got it right and it will pick up the opam release version instead of a git commit hash in release builds.